### PR TITLE
MMA AI 📊 show matchup odds charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -142,6 +142,33 @@ def get_events():
         logger.error(f"Error fetching event data: {str(e)}")
         return jsonify({'error': str(e)}), 500
 
+# New endpoint to serve odds movement data for betting trends
+@app.route('/api/data/odds-movements', methods=['GET'])
+def get_odds_movements():
+    """Return odds movement history from CSV"""
+    try:
+        odds_df = pd.read_csv('data/ufc_odds_movements_fightoddsio.csv')
+
+        # Extract timestamps from filenames
+        odds_df['time_before'] = odds_df['file1'].str.extract(r'(\d{8}_\d{4})')[0]
+        odds_df['time_after'] = odds_df['file2'].str.extract(r'(\d{8}_\d{4})')[0]
+
+        # Convert to ISO date strings for easier parsing on iOS
+        odds_df['time_before'] = pd.to_datetime(odds_df['time_before'], format='%Y%m%d_%H%M').astype(str)
+        odds_df['time_after'] = pd.to_datetime(odds_df['time_after'], format='%Y%m%d_%H%M').astype(str)
+
+        odds_data = json.loads(odds_df.to_json(orient='records'))
+
+        response = {
+            'timestamp': datetime.now().isoformat(),
+            'odds': odds_data
+        }
+
+        return jsonify(response)
+    except Exception as e:
+        logger.error(f"Error fetching odds movements: {str(e)}")
+        return jsonify({'error': str(e)}), 500
+
 @app.route('/api/data/version', methods=['GET'])
 def get_data_version():
     try:

--- a/mma-ai-swift/mma-ai-swift.xcodeproj/project.pbxproj
+++ b/mma-ai-swift/mma-ai-swift.xcodeproj/project.pbxproj
@@ -24,8 +24,12 @@
 		73A960442D82E0ED009B6A7E /* ConversationHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A960402D82E0ED009B6A7E /* ConversationHistoryView.swift */; };
 		8A1234561234567800000001 /* MMAApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000002 /* MMAApp.swift */; };
 		8A1234561234567800000003 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000004 /* ContentView.swift */; };
-		8A1234561234567800000005 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000006 /* ChatViewModel.swift */; };
-		8A1234561234567800000024 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000023 /* Assets.xcassets */; };
+                8A1234561234567800000005 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000006 /* ChatViewModel.swift */; };
+                E3245622F28F745A3F2F9AF5 /* OddsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 580BE9B2147E4E5030A8B100 /* OddsModels.swift */; };
+                A4DEAA534AE1C66168DC703F /* OddsMonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F7352C5FE1560EDE82D274 /* OddsMonitoringView.swift */; };
+                9B24F604B79CFDC8D36DEB2C /* OddsHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C8B05FE9CF1944671B66CD /* OddsHistoryView.swift */; };
+                5DC28B05D2354E72BA16A2F4 /* FightOddsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBDB8F7497D4000BD06507F /* FightOddsChart.swift */; };
+                8A1234561234567800000024 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8A1234561234567800000023 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,10 +50,14 @@
 		73A960412D82E0ED009B6A7E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		8A1234561234567800000002 /* MMAApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MMAApp.swift; sourceTree = "<group>"; };
 		8A1234561234567800000004 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		8A1234561234567800000006 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
-		8A1234561234567800000007 /* mma-ai-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "mma-ai-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A1234561234567800000022 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8A1234561234567800000023 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+                8A1234561234567800000006 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+                580BE9B2147E4E5030A8B100 /* OddsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OddsModels.swift; sourceTree = "<group>"; };
+                E9F7352C5FE1560EDE82D274 /* OddsMonitoringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OddsMonitoringView.swift; sourceTree = "<group>"; };
+                14C8B05FE9CF1944671B66CD /* OddsHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OddsHistoryView.swift; sourceTree = "<group>"; };
+                AFBDB8F7497D4000BD06507F /* FightOddsChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FightOddsChart.swift; sourceTree = "<group>"; };
+                8A1234561234567800000007 /* mma-ai-swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "mma-ai-swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+                8A1234561234567800000022 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                8A1234561234567800000023 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,21 +88,25 @@
 				8A1234561234567800000004 /* ContentView.swift */,
 				73A960402D82E0ED009B6A7E /* ConversationHistoryView.swift */,
 				736B5A772D82E22A008D7A55 /* DashboardView.swift */,
-				732A66B42DA8CBA5003842BA /* DataManager.swift */,
-				738B03132D82DE4B0065813D /* EventCard.swift */,
-				73130C472D8AC8B6004A6AD5 /* ExportView.swift */,
-				738B03142D82DE4B0065813D /* FighterCard.swift */,
-				7378521A2D8AFB6400023875 /* FighterDashboardView.swift */,
-				733DFFE62D8AECA1004EC7B8 /* FighterProfileView.swift */,
-				738B030F2D82DD5B0065813D /* LaunchScreen.swift */,
-				731D8CC52D8AC1B4004F58E6 /* Message.swift */,
-				8A1234561234567800000002 /* MMAApp.swift */,
-				732A66B22DA8CB7A003842BA /* Models.swift */,
-				737E315D2D908A53009EBF34 /* NetworkManager.swift */,
-				73A960412D82E0ED009B6A7E /* SettingsView.swift */,
-				731C84C82DA9698000361A5E /* SharedComponents.swift */,
-				8A1234561234567800000023 /* Assets.xcassets */,
-			);
+                                732A66B42DA8CBA5003842BA /* DataManager.swift */,
+                                738B03132D82DE4B0065813D /* EventCard.swift */,
+                                73130C472D8AC8B6004A6AD5 /* ExportView.swift */,
+                                738B03142D82DE4B0065813D /* FighterCard.swift */,
+                                7378521A2D8AFB6400023875 /* FighterDashboardView.swift */,
+                                733DFFE62D8AECA1004EC7B8 /* FighterProfileView.swift */,
+                                738B030F2D82DD5B0065813D /* LaunchScreen.swift */,
+                                731D8CC52D8AC1B4004F58E6 /* Message.swift */,
+                                8A1234561234567800000002 /* MMAApp.swift */,
+                                732A66B22DA8CB7A003842BA /* Models.swift */,
+                                737E315D2D908A53009EBF34 /* NetworkManager.swift */,
+                                73A960412D82E0ED009B6A7E /* SettingsView.swift */,
+                                731C84C82DA9698000361A5E /* SharedComponents.swift */,
+                                580BE9B2147E4E5030A8B100 /* OddsModels.swift */,
+                                E9F7352C5FE1560EDE82D274 /* OddsMonitoringView.swift */,
+                                14C8B05FE9CF1944671B66CD /* OddsHistoryView.swift */,
+                                AFBDB8F7497D4000BD06507F /* FightOddsChart.swift */,
+                                8A1234561234567800000023 /* Assets.xcassets */,
+                        );
 			path = "mma-ai-swift";
 			sourceTree = "<group>";
 		};
@@ -189,11 +201,15 @@
 				73A960432D82E0ED009B6A7E /* SettingsView.swift in Sources */,
 				73A960442D82E0ED009B6A7E /* ConversationHistoryView.swift in Sources */,
 				731D8CC62D8AC1B7004F58E6 /* Message.swift in Sources */,
-				733DFFE72D8AECA1004EC7B8 /* FighterProfileView.swift in Sources */,
-				8A1234561234567800000001 /* MMAApp.swift in Sources */,
-				736B5A782D82E22A008D7A55 /* DashboardView.swift in Sources */,
-				8A1234561234567800000005 /* ChatViewModel.swift in Sources */,
-			);
+                                733DFFE72D8AECA1004EC7B8 /* FighterProfileView.swift in Sources */,
+                                8A1234561234567800000001 /* MMAApp.swift in Sources */,
+                                736B5A782D82E22A008D7A55 /* DashboardView.swift in Sources */,
+                                8A1234561234567800000005 /* ChatViewModel.swift in Sources */,
+                                E3245622F28F745A3F2F9AF5 /* OddsModels.swift in Sources */,
+                                A4DEAA534AE1C66168DC703F /* OddsMonitoringView.swift in Sources */,
+                                9B24F604B79CFDC8D36DEB2C /* OddsHistoryView.swift in Sources */,
+                                5DC28B05D2354E72BA16A2F4 /* FightOddsChart.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */

--- a/mma-ai-swift/mma-ai-swift/DashboardView.swift
+++ b/mma-ai-swift/mma-ai-swift/DashboardView.swift
@@ -22,6 +22,10 @@ struct DashboardView: View {
                 TabButton(title: "News", isSelected: selectedTab == 3) {
                     selectedTab = 3
                 }
+
+                TabButton(title: "Odds", isSelected: selectedTab == 4) {
+                    selectedTab = 4
+                }
             }
             .background(AppTheme.cardBackground)
             
@@ -37,6 +41,8 @@ struct DashboardView: View {
                         RankingsView()
                     case 3:
                         NewsView()
+                    case 4:
+                        OddsMonitoringView()
                     default:
                         EmptyView()
                     }

--- a/mma-ai-swift/mma-ai-swift/EventCard.swift
+++ b/mma-ai-swift/mma-ai-swift/EventCard.swift
@@ -32,6 +32,7 @@ struct EventCard: View {
     @State private var showMainCard = true
     @State private var showPrelims = false
     @State private var selectedFighter: FighterStats? = nil
+    @State private var selectedFightForOdds: Fight? = nil
     let isPastEvent: Bool
     
     init(event: EventInfo, isPastEvent: Bool = false) {
@@ -164,6 +165,9 @@ struct EventCard: View {
                 }
             )
         }
+        .sheet(item: $selectedFightForOdds) { fight in
+            FightOddsView(fight: fight)
+        }
     }
     
     private func loadFighterData(name: String, id: Int) {
@@ -274,6 +278,23 @@ struct EventCard: View {
                     .buttonStyle(BorderlessButtonStyle())
                     .hoverEffect(.highlight)
                     .help("Generate AI fight prediction")
+
+                    // Odds chart button
+                    Button(action: {
+                        selectedFightForOdds = fight
+                    }) {
+                        Image(systemName: "chart.xyaxis.line")
+                            .font(.caption)
+                            .padding(4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(Color.gray.opacity(0.5), lineWidth: 1)
+                            )
+                    }
+                    .padding(.leading, 4)
+                    .buttonStyle(BorderlessButtonStyle())
+                    .hoverEffect(.highlight)
+                    .help("Show odds movement")
                 }
             }
         }

--- a/mma-ai-swift/mma-ai-swift/FightOddsChart.swift
+++ b/mma-ai-swift/mma-ai-swift/FightOddsChart.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Charts
+
+/// Line chart comparing odds movement for both fighters in a matchup.
+struct OddsFightChart: View {
+    let fight: Fight
+    let movements: [OddsMovement]
+
+    private func points(for fighter: String) -> [OddsPoint] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        var buckets: [Date: [Double]] = [:]
+        for move in movements where move.fighter == fighter {
+            if let ts = move.time_after, let date = formatter.date(from: ts) {
+                buckets[date, default: []].append(move.odds_after)
+            }
+        }
+        return buckets.map { date, values in
+            let avg = values.reduce(0, +) / Double(values.count)
+            return OddsPoint(date: date, value: avg)
+        }.sorted { $0.date < $1.date }
+    }
+
+    var body: some View {
+        Chart {
+            ForEach(points(for: fight.redCorner)) { point in
+                LineMark(x: .value("Time", point.date),
+                         y: .value("Odds", point.value))
+                    .foregroundStyle(.red)
+            }
+            ForEach(points(for: fight.blueCorner)) { point in
+                LineMark(x: .value("Time", point.date),
+                         y: .value("Odds", point.value))
+                    .foregroundStyle(.blue)
+            }
+        }
+    }
+}
+
+/// Simple wrapper used when presenting the chart in a sheet
+struct FightOddsView: View {
+    let fight: Fight
+    @ObservedObject private var dataManager = FighterDataManager.shared
+
+    var body: some View {
+        VStack {
+            Text("\(fight.redCorner) vs \(fight.blueCorner)")
+                .font(.headline)
+                .foregroundColor(.white)
+            OddsFightChart(fight: fight, movements: dataManager.oddsMovements)
+                .frame(height: 250)
+        }
+        .padding()
+        .background(AppTheme.background)
+    }
+}

--- a/mma-ai-swift/mma-ai-swift/Models.swift
+++ b/mma-ai-swift/mma-ai-swift/Models.swift
@@ -44,6 +44,11 @@ struct Fight: Codable {
     let time: String
 }
 
+// Provide identity and hashing for Fight so it can be used in pickers and lists
+extension Fight: Identifiable, Hashable {
+    var id: String { "\(redCorner)_vs_\(blueCorner)_\(weightClass)" }
+}
+
 struct FightResult: Codable {
     let opponent: String
     let opponentID: Int

--- a/mma-ai-swift/mma-ai-swift/NetworkManager.swift
+++ b/mma-ai-swift/mma-ai-swift/NetworkManager.swift
@@ -558,7 +558,42 @@ class NetworkManager {
             }
         }
     }
-    
+
+    // Fetch odds movement history from the backend
+    func fetchOddsMovements() async throws -> [OddsMovement] {
+        if !isServerAvailable {
+            isServerAvailable = await checkServerAvailability()
+            if !isServerAvailable {
+                print("⚠️ Server not available for fetching odds movements")
+                throw NetworkError.serverUnavailable
+            }
+        }
+
+        let endpoint = "\(baseURL)/data/odds-movements"
+        print("🔄 Fetching odds movements from: \(endpoint)")
+
+        guard let url = URL(string: endpoint) else {
+            throw NetworkError.invalidURL
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                throw NetworkError.invalidResponse
+            }
+
+            let decoder = JSONDecoder()
+            let oddsResponse = try decoder.decode(OddsResponse.self, from: data)
+            print("✅ Fetched \(oddsResponse.odds.count) odds movement records")
+            return oddsResponse.odds
+        } catch {
+            print("⚠️ Odds movement fetch error: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
     // Helper function to add spaces to fighter names
     private func formatFighterName(_ name: String) -> String {
         // Use regular expression to insert spaces before uppercase letters

--- a/mma-ai-swift/mma-ai-swift/OddsHistoryView.swift
+++ b/mma-ai-swift/mma-ai-swift/OddsHistoryView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import Charts
+
+struct OddsHistoryView: View {
+    @ObservedObject private var dataManager = FighterDataManager.shared
+    @State private var searchText: String = ""
+
+    private var filteredFighters: [String] {
+        let names = Array(Set(dataManager.oddsMovements.map { $0.fighter }))
+        if searchText.isEmpty { return names.sorted() }
+        return names.filter { $0.localizedCaseInsensitiveContains(searchText) }.sorted()
+    }
+
+    var body: some View {
+        VStack {
+            TextField("Search Fighter", text: $searchText)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+
+            ScrollView {
+                ForEach(filteredFighters, id: \.self) { fighter in
+                    VStack(alignment: .leading) {
+                        Text(fighter)
+                            .font(.headline)
+                            .foregroundColor(.white)
+                        OddsLineChart(fighter: fighter, movements: dataManager.oddsMovements)
+                            .frame(height: 200)
+                    }
+                    .padding()
+                }
+            }
+        }
+        .background(AppTheme.background)
+    }
+}

--- a/mma-ai-swift/mma-ai-swift/OddsModels.swift
+++ b/mma-ai-swift/mma-ai-swift/OddsModels.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct OddsMovement: Codable, Identifiable {
+    let id = UUID()
+    let file1: String
+    let file2: String
+    let fighter: String
+    let sportsbook: String
+    let odds_before: Double
+    let odds_after: Double
+    let time_before: String?
+    let time_after: String?
+}
+
+struct OddsResponse: Codable {
+    let timestamp: String
+    let odds: [OddsMovement]
+}
+
+struct OddsPoint: Identifiable {
+    let id = UUID()
+    let date: Date
+    let value: Double
+}

--- a/mma-ai-swift/mma-ai-swift/OddsMonitoringView.swift
+++ b/mma-ai-swift/mma-ai-swift/OddsMonitoringView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import Charts
+
+struct OddsMonitoringView: View {
+    @ObservedObject private var dataManager = FighterDataManager.shared
+    @State private var selectedFight: Fight?
+
+    private var fights: [Fight] {
+        dataManager.upcomingEvents.flatMap { $0.fights }
+    }
+
+    var body: some View {
+        VStack {
+            if dataManager.oddsMovements.isEmpty {
+                ProgressView("Loading odds...")
+            } else {
+                Picker("Matchup", selection: $selectedFight) {
+                    ForEach(fights) { fight in
+                        Text("\(fight.redCorner) vs \(fight.blueCorner)").tag(Optional(fight))
+                    }
+                }
+                .pickerStyle(.menu)
+                .padding()
+                .onAppear {
+                    if selectedFight == nil { selectedFight = fights.first }
+                }
+
+                if let fight = selectedFight {
+                    OddsFightChart(fight: fight, movements: dataManager.oddsMovements)
+                        .frame(height: 250)
+                        .padding()
+                }
+            }
+        }
+        .background(AppTheme.background)
+    }
+}
+
+struct OddsLineChart: View {
+    let fighter: String
+    let movements: [OddsMovement]
+
+    private var points: [OddsPoint] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return movements.filter { $0.fighter == fighter }.compactMap { move in
+            if let ts = move.time_after, let date = formatter.date(from: ts) {
+                return OddsPoint(date: date, value: move.odds_after)
+            }
+            return nil
+        }.sorted { $0.date < $1.date }
+    }
+
+    var body: some View {
+        Chart(points) { point in
+            LineMark(x: .value("Time", point.date),
+                     y: .value("Odds", point.value))
+                .foregroundStyle(.yellow)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- give `Fight` a Hashable/Identifiable id so it can be used in pickers
- update odds monitoring to choose a matchup and show both fighters
- add `FightOddsChart` view for side‑by‑side line graphs
- show odds chart button on every fight row in `EventCard`
- include new chart file in the Xcode project

## Testing
- `python -m py_compile app.py`
- `swiftc -parse mma-ai-swift/mma-ai-swift/OddsModels.swift mma-ai-swift/mma-ai-swift/OddsMonitoringView.swift mma-ai-swift/mma-ai-swift/OddsHistoryView.swift mma-ai-swift/mma-ai-swift/FightOddsChart.swift`
- `swiftc -parse mma-ai-swift/mma-ai-swift/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_684f53e3a2248320bf153590441ff09c