### PR TITLE
include fighter ids in upcoming events

### DIFF
--- a/app.py
+++ b/app.py
@@ -423,6 +423,10 @@ def get_upcoming_events():
     try:
         # Load the upcoming events CSV file
         upcoming_df = pd.read_csv('data/upcoming_event_data_sherdog.csv')
+
+        # Ensure fighter ID columns are integers
+        upcoming_df["Fighter 1 ID"] = upcoming_df["Fighter 1 ID"].fillna(0).astype(int)
+        upcoming_df["Fighter 2 ID"] = upcoming_df["Fighter 2 ID"].fillna(0).astype(int)
         
         # Group by event name to organize fights under each event
         events = []
@@ -435,6 +439,8 @@ def get_upcoming_events():
                 fight = {
                     'fighter1': row['Fighter 1'],
                     'fighter2': row['Fighter 2'],
+                    'fighter1ID': int(row['Fighter 1 ID']),
+                    'fighter2ID': int(row['Fighter 2 ID']),
                     'weightClass': row['Weight Class'],
                     'fightType': row['Fight Type'],
                     'round': None,  # These are upcoming so no result yet

--- a/mma-ai-swift/mma-ai-swift/Models.swift
+++ b/mma-ai-swift/mma-ai-swift/Models.swift
@@ -432,8 +432,10 @@ struct APIEvent: Codable {
         fighter1 = try container.decode(String.self, forKey: .fighter1)
         fighter2 = try container.decode(String.self, forKey: .fighter2)
         
-        fighter1ID = (try? container.decode(Int.self, forKey: .fighter1ID)) ?? 0
-        fighter2ID = (try? container.decode(Int.self, forKey: .fighter2ID)) ?? 0
+        fighter1ID = (try? container.decode(Int.self, forKey: .fighter1ID)) ??
+            (Int(try container.decodeIfPresent(String.self, forKey: .fighter1ID) ?? "") ?? 0)
+        fighter2ID = (try? container.decode(Int.self, forKey: .fighter2ID)) ??
+            (Int(try container.decodeIfPresent(String.self, forKey: .fighter2ID) ?? "") ?? 0)
         
         location = try container.decodeIfPresent(String.self, forKey: .location)
         date = try container.decodeIfPresent(String.self, forKey: .date)

--- a/mma-ai-swift/mma-ai-swift/NetworkManager.swift
+++ b/mma-ai-swift/mma-ai-swift/NetworkManager.swift
@@ -389,10 +389,12 @@ class NetworkManager {
                     let mainCard: [UpcomingFight]
                     let prelims: [UpcomingFight]
                     let allFights: [UpcomingFight]
-                    
+
                     struct UpcomingFight: Codable {
                         let fighter1: String
                         let fighter2: String
+                        let fighter1ID: Int?
+                        let fighter2ID: Int?
                         let weightClass: String?
                         let fightType: String?
                         let round: Int?
@@ -434,6 +436,8 @@ class NetworkManager {
                             "Event Date": event.date as Any,
                             "Fighter 1": formattedFighter1,
                             "Fighter 2": formattedFighter2,
+                            "Fighter 1 ID": fight.fighter1ID ?? 0,
+                            "Fighter 2 ID": fight.fighter2ID ?? 0,
                             "Weight Class": fight.weightClass as Any,
                             "Winning Fighter": fight.winner as Any,
                             "Winning Method": fight.method as Any,

--- a/scripts/scrape_upcoming_event_sherdog.py
+++ b/scripts/scrape_upcoming_event_sherdog.py
@@ -425,6 +425,11 @@ def scrape_single_event(event_url):
             # Create DataFrame and save to CSV
             if all_data:
                 df = pd.DataFrame(all_data)
+
+                # Ensure fighter ID columns are preserved as integers
+                df['Fighter 1 ID'] = pd.to_numeric(df['Fighter 1 ID'], errors='coerce').fillna(0).astype(int)
+                df['Fighter 2 ID'] = pd.to_numeric(df['Fighter 2 ID'], errors='coerce').fillna(0).astype(int)
+
                 file_path = './data/upcoming_event_data_sherdog.csv'
                 
                 # Create data directory if it doesn't exist


### PR DESCRIPTION
## Summary
- keep fighter ID columns when scraping upcoming events
- send IDs from `/api/data/upcoming`
- decode fighter ID fields on iOS

## Testing
- `python -m py_compile app.py scripts/scrape_upcoming_event_sherdog.py`


------
https://chatgpt.com/codex/tasks/task_e_6879d929bd5083208f62c2dd8673bf9e